### PR TITLE
Compute socket host dynamically

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { CaseComponent } from './components/case/case.component';
 import { RateCardsComponent } from './components/rate-cards/rate-cards.component';
 import {SocketIoConfig, SocketIoModule} from "ngx-socket-io";
 import {ToastrModule} from "ngx-toastr";
+import {environment} from "../environments/environment";
 import { HotbitsComponent } from './components/hotbits/hotbits.component';
 import { RadionicsDeviceBase44Component } from './components/radionics-device-base44/radionics-device-base44.component';
 import { AppsComponent } from './components/apps/apps.component';
@@ -22,8 +23,10 @@ import {BroadcastComponent} from "./components/broadcast/broadcast.component";
 import {LoadingInterceptor} from "./services/loadingInterceptor";
 import {HTTP_INTERCEPTORS} from "@angular/common/http";
 
+const socketHost = environment.socketHost || window.location.hostname;
+const url = `http://${socketHost}:80`;
 const config: SocketIoConfig = {
-  url: 'http://localhost:80',
+  url,
   options: {
     transports: ['websocket'],
     reconnection: true,

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  baseUrl: "/"
+  baseUrl: "/",
+  socketHost: undefined
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -4,5 +4,6 @@
 
 export const environment = {
   production: false,
-  baseUrl: "http://localhost/"
+  baseUrl: "http://localhost/",
+  socketHost: undefined
 };


### PR DESCRIPTION
## Summary
- configure websocket url using the current hostname
- expose optional `socketHost` in environment files

## Testing
- `npm run build` *(fails: `ng: not found`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688330f7b46083258085396ead6e35fb