### PR TITLE
Add Socket.IO ping handler

### DIFF
--- a/py/main.py
+++ b/py/main.py
@@ -185,6 +185,11 @@ class AetherOnePy:
             emit('server_update', {'message': 'Server connected to websockets!'}, broadcast=True)
             emit('broadcast_info', {'message': 'Broadcast messaging ready!'}, broadcast=True)
 
+        @self.socketio.on('ping')
+        def handle_ping():
+            logging.info('Received ping event')
+            emit('pong')
+
         # Restart application
         # First get the new code from the repository
         # Second check and install the required packages


### PR DESCRIPTION
## Summary
- register new `'ping'` Socket.IO event in `AetherOnePy.setup_routes`
- respond with `'pong'` and log when ping is received

## Testing
- `pytest -q`
- `pip install flask flask_cors flask_socketio flasgger psutil Pillow qrcode python-dateutil openai` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688331160e9483258f9cb5a9780c6bcd