### PR TITLE
Fix static file handler for socket.io

### DIFF
--- a/py/main.py
+++ b/py/main.py
@@ -17,7 +17,7 @@ from flasgger import Swagger
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 os.environ['FLASK_ENV'] = 'development'
 
-from flask import Flask, jsonify, request, send_from_directory, send_file, Response
+from flask import Flask, jsonify, request, send_from_directory, send_file, Response, abort
 from flask_cors import CORS
 from flask_socketio import SocketIO, emit
 from PIL import ImageDraw, ImageFont
@@ -177,6 +177,8 @@ class AetherOnePy:
         # Serving static files, like images, css, js, etc.
         @self.app.route('/<path:path>')
         def static_files(path):
+            if path.startswith('socket.io'):
+                abort(404)
             return send_from_directory('../ui/dist/ui/browser/', path)
 
         # Reacting to the websockets connect event, in order to get the UI know you are connected


### PR DESCRIPTION
## Summary
- update flask import to include `abort`
- return 404 in `static_files` when path is under `socket.io`

## Testing
- `pytest -q`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_6883314abe6c83259ace5c33e2fe9fed