### PR TITLE
Enable dynamic WebSocket port

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -24,7 +24,8 @@ import {LoadingInterceptor} from "./services/loadingInterceptor";
 import {HTTP_INTERCEPTORS} from "@angular/common/http";
 
 const socketHost = environment.socketHost || window.location.hostname;
-const url = `http://${socketHost}:80`;
+const socketPort = environment.socketPort || window.location.port || '80';
+const url = `http://${socketHost}:${socketPort}`;
 const config: SocketIoConfig = {
   url,
   options: {

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
   baseUrl: "/",
-  socketHost: undefined
+  socketHost: undefined,
+  socketPort: undefined
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -5,5 +5,6 @@
 export const environment = {
   production: false,
   baseUrl: "http://localhost/",
-  socketHost: undefined
+  socketHost: undefined,
+  socketPort: undefined
 };


### PR DESCRIPTION
## Summary
- let the WebSocket port be configured at runtime
- expose optional `socketPort` in Angular environments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68834791b5cc832592497136ae45aaea